### PR TITLE
Refactor: Rename groups to tags

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -39,11 +39,11 @@ Devices.prototype.list = function(params, callback) {
     return this.client.get("/devices", { qs: params || {} }, callback);
 };
 
-// List the devices groups for the authenticated user
+// List the devices tags for the authenticated user
 //
-// https://m2x.att.com/developer/documentation/v2/device#List-Device-Groups
-Devices.prototype.groups = function(callback) {
-    return this.client.get("/devices/groups", callback);
+// https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags
+Devices.prototype.tags = function(callback) {
+    return this.client.get("/devices/tags", callback);
 };
 
 // Create a new device


### PR DESCRIPTION
The groups concept has been deprecated in favor of [tags](https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags).

Add the necessary changes to this library to reflect that change.