### PR TITLE
But: Syntax error in the update single example

### DIFF
--- a/examples/update-single.js
+++ b/examples/update-single.js
@@ -29,7 +29,7 @@ m2xClient.devices.updateStream(config.device, stream, stream_params, function(re
         console.log("I'm updating stream values! (Press CTRL + C to stop)");
 
         // Update the latest stream value to our new value
-        m2xClient.devices.updateStreamValue(config.device, stream, {"value": new_value}, function(result) {
+        m2xClient.devices.setStreamValue(config.device, stream, {"value": new_value}, function(result) {
             if (result.isError()) {
                 console.log(result.error());
             }


### PR DESCRIPTION
In the example code in https://github.com/attm2x/m2x-tessel/blob/master/examples/update-single.js, there's a typo. The example says:

```js
m2xClient.devices.updateStreamValue(config.device, stream, {"value": new_value}, function(result {
  if (result.isError()) {
    console.log(result.error());
  }
});
```
but in reality, it's supposed to be:
```js
m2xClient.devices.setStreamValue(config.device, stream, {"value": new_value}, function(result) {
  if (result.isError()) {
    console.log(result.error());
  }
});
```